### PR TITLE
Extract the relations info from pointers index

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-var async = require( 'async');
+var async = require('async');
 var fs = require('fs');
 var url = require('url');
 

--- a/app.js
+++ b/app.js
@@ -943,6 +943,52 @@ app.get('/sense-tagging-detail',
 
         });
 
+app.get('/list-synsets/:type',
+        function(req,res)
+        {
+            var query = wn.createQuery()
+                .q('*:*')
+                .matchFilter("rdf_type", req.params.type)
+                .fl(["word_en","word_pt","doc_id"])
+                .rows(1000000);
+            wn.search(query,
+                      function(err, doc)
+                      {
+                          if (!err)
+                          {
+                              res.json(doc.response.docs);
+                          } else 
+                          {
+                              res.json(err);
+                          }
+                      });
+
+        });
+
+app.get('/list-suggestions/:type',
+        function(req,res)
+        {
+            var query = wnchanges.createQuery()
+                .q('*:*')
+                .matchFilter("type", "suggestion")
+                .matchFilter("doc_type", "synset")
+                .matchFilter("action", req.params.type)
+                .fl(["doc_id","params"])
+                .rows(1000000);
+            wnchanges.search(query,
+                      function(err, doc)
+                      {
+                          if (!err)
+                          {
+                              res.json(doc.response.docs);
+                          } else 
+                          {
+                              res.json(err);
+                          }
+                      });
+
+        });
+
 var host = (process.env.VCAP_APP_HOST || 'localhost');
 // The port on the DEA for communication with the application:
 var port = (process.env.VCAP_APP_PORT || 3000);

--- a/workflow.js
+++ b/workflow.js
@@ -27,6 +27,11 @@ exports.getDocument = function(id, callback)
   localGetDocument(id, callback);
 }
 
+exports.getSynsetPointers = function(id, callback)
+{
+   localGetSynsetPointers(id, callback);
+}
+
 function localGetPointers (synset, word, callback)
 {
     var params = {};
@@ -47,8 +52,9 @@ function localGetPointers (synset, word, callback)
                     function (err, result)
                     {
                         callback(null, result.response.docs);
-                    });
-}
+    });
+} 
+
 
 function localGetDocument(id, callback)
 {
@@ -56,6 +62,43 @@ function localGetDocument(id, callback)
   
   wn.search(query,
             function(err, doc)
+            {
+               if (!err)
+              {
+                if (DEBUG && doc.respose.numFound > 1)
+                {
+                  console.log('WARNING: more than one document found!', id);
+                }
+
+                if (DEBUG && doc.response.numFound == 0)
+                {
+                  console.log('WARNING: no document found!', id);
+                }
+
+                if (doc.response.numFound >= 1)
+                {
+		    callback(null, doc.response.docs[0]);
+                }
+                else
+                {
+                  callback({'error' : 'document-not-found'}, null);
+                }
+              }
+              else
+              {
+                callback({'error': err}, null);
+              }
+            });
+}
+
+
+function localGetSynsetPointers (id, callback)
+{
+  var sourceSynset = "https://w3id.org/own-pt/wn30-en/instances/synset-" + id;
+  var query = pointers.createQuery().q({source_synset:escapeSpecialChars(sourceSynset)});
+   
+  pointers.search(query,
+      function(err, doc)
             {
               if (!err)
               {
@@ -71,7 +114,7 @@ function localGetDocument(id, callback)
 
                 if (doc.response.numFound >= 1)
                 {
-                  callback(null, doc.response.docs[0]);
+		    callback(null, doc.response.docs);
                 }
                 else
                 {
@@ -82,7 +125,7 @@ function localGetDocument(id, callback)
               {
                 callback({'error': err}, null);
               }
-            });
+            });    
 }
 
 exports.acceptSuggestion = function(id, callback)


### PR DESCRIPTION
The app.js and the workflow.js where modified to consult the pointers index and construct the relations informations about synsets. Its is important to point out that the wn index still have infomation only the pointers index should have e.g.: "partHolonymOf". That implies that functions like wordnet.getPredicates()  be updated in order to return only predicates and not what is now considered relations.
